### PR TITLE
change "dick" to "fett" for "schrift-gewicht"

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ var mapProperties = {
 var mapValues = {
     'absolute': 'absolut',
     'auto': 'automatisch',
-    'bold': 'dick',
+    'bold': 'fett',
     'fixed': 'fixiert',
     'hidden': 'versteckt',
     'inherit': 'erben',


### PR DESCRIPTION
The term "fett" is the typographically better one here. (Compare font names with "Fette" in their name.)
